### PR TITLE
Drop hard-coded references to /home/ico

### DIFF
--- a/ansible/roles/vim/tasks/main.yml
+++ b/ansible/roles/vim/tasks/main.yml
@@ -2,14 +2,14 @@
 - name: Install vim config file
   copy:
     src: vimrc
-    dest: /home/ico/.vimrc
+    dest: '{{ ansible_env.HOME }}/.vimrc'
 
 - name: Create Colorscheme directory
   file:
-    path: /home/ico/.vim/colors
+    path: '{{ ansible_env.HOME }}/.vim/colors'
     state: directory
 
 - name: Install vim colorscheme file(s)
   copy:
     src: sublimemonokai.vim
-    dest: /home/ico/.vim/colors/sublimemonokai.vim
+    dest: '{{ ansible_env.HOME }}/.vim/colors/sublimemonokai.vim'


### PR DESCRIPTION
The "vim" role contains hard-coded references to /home/ico. It uses
these when installing files, such as /home/ico/.vimrc. This works fine
so long as this Ansible code is only executed for the user ico, and so
long as their home directory does exist at /home/ico (as opposed to e.g.
/home/icobob).

In general, though, it is better to avoid hard-coding this type of
information. Use the `ansible_env` variable to do so. Here are some
sample Ansible tasks and the values they would likely emit:

```yaml
- name: Print home directory of connecting user
    debug:
    var: ansible_env.HOME

- name: Print home directory of root
    debug:
    var: ansible_env.HOME
    become: true

- name: Print home directory of alice
    debug:
    var: ansible_env.HOME
    become: true
    become_user: alice
```

For more information on this topic, see:

* https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-access-shell-environment-variables
* https://github.com/Ichimonji10/impedimenta/tree/master/ansible/junk-ansible-env

Make sure to test before merging.